### PR TITLE
Fixed on-push: use current branch instead of master

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{github.ref}}
+
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -23,6 +23,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{github.ref}}
+    
+    - name: Fetch Tags
+      run: git fetch --prune --unshallow --tags
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/GenDriverAPI/src/main/java/com/smartgridready/driver/api/messaging/GenMessagingClient.java
+++ b/GenDriverAPI/src/main/java/com/smartgridready/driver/api/messaging/GenMessagingClient.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
  * Interface to be used by smartgridready messaging client implementations.
  */
 @SuppressWarnings("unused")
-public interface MessagingClient extends Closeable {
+public interface GenMessagingClient extends Closeable {
 
     /**
      * This method publishes a message to the given topic. The method is blocking

--- a/GenDriverAPI/src/main/java/com/smartgridready/driver/api/messaging/GenMessagingClientFactory.java
+++ b/GenDriverAPI/src/main/java/com/smartgridready/driver/api/messaging/GenMessagingClientFactory.java
@@ -5,7 +5,7 @@ import com.smartgridready.ns.v0.MessagingInterfaceDescription;
 /**
  * Interface to be used to create smartgridready messaging clients.
  */
-public interface MessagingClientFactory {
+public interface GenMessagingClientFactory {
 
     /**
      * Factory method to create a new instance of the smartgridready messaging client.
@@ -13,5 +13,5 @@ public interface MessagingClientFactory {
      * @param interfaceDescription Describes the messaging interface and it's parameters.
      * @return A new messaging client instance.
      */
-    MessagingClient create(MessagingInterfaceDescription interfaceDescription);
+    GenMessagingClient create(MessagingInterfaceDescription interfaceDescription);
 }


### PR DESCRIPTION
Fixed the on-push GitHub Action to use the currently pushed branch instead of master on checkout.